### PR TITLE
fix setDeep non-nested keypaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.4.1
 
-* Fix `setDeep` method when keypath is a non-nested data root key ([#3](https://github.com/sveltejs/svelte-extras/issues/3))
+* Fix `setDeep` method when keypath is a non-nested data root key ([#5](https://github.com/sveltejs/svelte-extras/issues/5))
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # svelte-extras changelog
 
+## 1.4.1
+
+* Fix `setDeep` method when keypath is a non-nested data root key ([#3](https://github.com/sveltejs/svelte-extras/issues/3))
+
 ## 1.4.0
 
 * Add `getDeep` and `setDeep` methods

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-extras",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Extra methods for Svelte components",
   "main": "dist/svelte-extras.cjs.js",
   "module": "dist/svelte-extras.es.js",

--- a/src/get-set-deep.ts
+++ b/src/get-set-deep.ts
@@ -19,7 +19,6 @@ function setDeep( this:Component, keypath:string, value:any ) {
   const keys = keypath.replace( /\[(\d+)\]/g, '.$1' ).split( '.' );
   const lastKey = keys.pop();
 	
-	// If not a nested keypath
 	if ( keys[0] === undefined ) { 
 		const data:any = {};
 		data[ lastKey ] = value;

--- a/src/get-set-deep.ts
+++ b/src/get-set-deep.ts
@@ -18,6 +18,14 @@ function setDeep( this:Component, keypath:string, value:any ) {
   
   const keys = keypath.replace(/\[(\d+)\]/g, '.$1').split( '.' );
   const lastKey = keys.pop();
+	
+	// If not a nested keypath
+	if ( keys[0] === undefined ) { 
+		const data:any = {};
+		data[ lastKey ] = value;
+		this.set( data );
+		return;
+	}
   
   let object = this.get( keys[0] );
   for ( let i = 1; i < keys.length; i++ ) {

--- a/src/get-set-deep.ts
+++ b/src/get-set-deep.ts
@@ -19,6 +19,7 @@ function setDeep( this:Component, keypath:string, value:any ) {
   const keys = keypath.replace( /\[(\d+)\]/g, '.$1' ).split( '.' );
   const lastKey = keys.pop();
 	
+	// If not a nested keypath
 	if ( keys[0] === undefined ) { 
 		const data:any = {};
 		data[ lastKey ] = value;

--- a/src/get-set-deep.ts
+++ b/src/get-set-deep.ts
@@ -5,7 +5,7 @@ function getDeep( this:Component, keypath:string ) {
     return this.get(); 
   }
   
-  const keys = keypath.replace(/\[(\d+)\]/g, '.$1').split( '.' );
+  const keys = keypath.replace( /\[(\d+)\]/g, '.$1' ).split( '.' );
   let value = this.get( keys[0] );
   for ( let i = 1; i < keys.length; i++ ) {
     value = value[ keys[i] ];
@@ -16,7 +16,7 @@ function getDeep( this:Component, keypath:string ) {
 function setDeep( this:Component, keypath:string, value:any ) {
   if ( keypath === undefined ) { return; }
   
-  const keys = keypath.replace(/\[(\d+)\]/g, '.$1').split( '.' );
+  const keys = keypath.replace( /\[(\d+)\]/g, '.$1' ).split( '.' );
   const lastKey = keys.pop();
 	
 	// If not a nested keypath

--- a/test/tests.js
+++ b/test/tests.js
@@ -462,5 +462,23 @@ describe('svelte-extras', () => {
 			
 			assert.deepEqual( value, { bar: { nested: { array: [2] } } } );
 		});
+		
+		it('set a string value with a non-nested keypath', () => {
+			const { component } = setup(`{{foo}}`, 'bar');
+			
+			component.setDeep( 'foo', 'baz' );
+			const value = component.get( 'foo' );
+			
+			assert.equal( value, 'baz' );
+		});
+		
+		it('set an array value with a non-nested keypath', () => {
+			const { component } = setup(`{{foo}}`, [ 1, 2, 3 ]);
+			
+			component.setDeep( 'foo', [ 4, 5, 6 ] );
+			const value = component.get( 'foo' );
+			
+			assert.deepEqual( value, [ 4, 5, 6 ] );
+		});
 	});
 });


### PR DESCRIPTION
**Problem** 
When using the `setDeep` method for keypaths that are not nested it does not work.

Example: https://svelte.technology/repl?version=1.29.3&gist=d100d0b76009d898406e21aa1406240f

**One solution to the problem:**
```typescript
// If not a nested keypath
if ( keys[0] === undefined ) { 
  const data:any = {};
  data[ lastKey ] = value;
  this.set( data );
  return;
}
```
The fix above have been added with this PR.
