### PR TITLE
new option for tween { adjustDuration }

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The available options (and default values) are:
 * **duration** (400) — the duration of the tween
 * **easing** (x => x) — which easing function to use (see e.g. [eases-jsnext](https://github.com/rollup/eases-jsnext)))
 * **interpolate** (see above) — a function that generators a custom interpolator, for e.g. transitioning strings representing colors. Must take arguments `a` and `b` and return a function that takes a value `t` between 0 and 1
+* **adjustDuration** (false) — if `tween` is called on a key while a tween is already in progress on that key, adjust the duration of the new tween so that the same percentage of it remains that the previous tween had progressed. For example, If the previous tween's duration was 100ms and was aborted after 50ms, the tween that replaced it will be reduced by 50%.
 
 This method returns a promise with an additional `abort` method. The tween will be aborted automatically if `key` is updated separately, either by a second tween or via `component.set(...)`. The promise will not resolve if the tween is aborted.
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -308,6 +308,44 @@ describe('svelte-extras', () => {
 			});
 		});
 
+		it('adjusts the duration of a tween that replaced a tween in progress if { adjustDuration: true }', () => {
+			const { component, target, raf } = setup(`{{x}}`, {
+				x: 20
+			});
+
+			let tween = component.tween('x', 40, {
+				duration: 100
+			});
+
+			assert.equal(component.get('x'), 20);
+			assert.htmlEqual(target.innerHTML, '20');
+
+			// 40% through tween
+			raf.tick(40);
+			assert.equal(component.get('x'), 28);
+			assert.htmlEqual(target.innerHTML, '28');
+
+			// new tween will only use 40% of its duration, 40ms
+			tween = component.tween('x', 130, {
+				duration: 100,
+				adjustDuration: true
+			});
+
+
+			// 20ms later, but 50% done of 100ms
+			raf.tick(60);
+			assert.equal(component.get('x'), 79);
+			assert.htmlEqual(target.innerHTML, '79');
+
+			// 40 so far, yet 100% done
+			raf.tick(80);
+
+			return tween.then(() => {
+				assert.equal(component.get('x'), 130);
+				assert.htmlEqual(target.innerHTML, '130');
+			});
+		});
+
 		it('allows custom interpolators', () => {
 			const { component, target, raf } = setup(`{{x}}`, {
 				x: 'a'


### PR DESCRIPTION
Adds an option to `tween` so that when a tween is aborted by a new tween, the new tween's duration is adjusted according to how far the previous tween had progressed. This is like what svelte transitions do when a transition reverses an already running transition. [Brief chat discussion about this.](https://gitter.im/sveltejs/svelte?at=59a60deebc46472974d75e79)