### PR TITLE
implement observeMany

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './array-methods';
 export * from './tween';
 export * from './observe-deep';
+export * from './observe-many';
 export * from './get-set-deep';
 export * from './spring';

--- a/src/observe-many.ts
+++ b/src/observe-many.ts
@@ -1,0 +1,52 @@
+import { Component, Observer, ObserverOptions } from './interfaces';
+
+export function observeMany(
+	this: Component,
+	keys: string[],
+	callback: (newValue: any, oldValue: any) => void,
+	opts?: ObserverOptions
+) {
+	const defer = opts && opts.defer;
+	const init = !opts || opts.init !== false;
+
+	let values = init ?
+		keys.map(() => undefined) :
+		keys.map(key => this.get(key));
+
+	const dispatch = () => {
+		const state = this.get();
+		const oldValues = values;
+		values = keys.map(key => state[key]);
+
+		callback.call(this, values, oldValues);
+	};
+
+	if (init) dispatch();
+
+	let n = 0;
+
+	const preObserver = () => {
+		if (!n++ && !defer) dispatch();
+	};
+
+	const postObserver = () => {
+		if (!--n && defer) dispatch();
+	};
+
+	const observers: Observer[] = [];
+
+	keys.forEach(key => {
+		observers.push(
+			this.observe(key, preObserver, { init: false }),
+			this.observe(key, postObserver, { init: false, defer: true })
+		);
+	});
+
+	return {
+		cancel() {
+			observers.forEach(observer => {
+				observer.cancel();
+			});
+		}
+	};
+}

--- a/test/observeMany/index.js
+++ b/test/observeMany/index.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const setup = require('../setup.js');
+
+module.exports = () => {
+	describe('observeMany', () => {
+		it('fires once per set, however many properties change', () => {
+			const { component, target } = setup(`{{foo}} {{bar}}`, { foo: 1, bar: 2 });
+
+			const observed = [];
+
+			component.observeMany(['foo', 'bar'], (n, o) => {
+				observed.push([o, n, target.innerHTML]);
+			});
+
+			component.set({ foo: 3, bar: 4 });
+			component.set({ foo: 5 });
+			component.set({ bar: 6 });
+
+			assert.deepEqual(observed, [
+				[[undefined, undefined], [1, 2], '1 2'],
+				[[1, 2], [3, 4], '1 2'],
+				[[3, 4], [5, 4], '3 4'],
+				[[5, 4], [5, 6], '5 4']
+			]);
+		});
+
+		it('respects init: false', () => {
+			const { component, target } = setup(`{{foo}} {{bar}}`, { foo: 1, bar: 2 });
+
+			const observed = [];
+
+			component.observeMany(['foo', 'bar'], (n, o) => {
+				observed.push([o, n, target.innerHTML]);
+			}, {
+				init: false
+			});
+
+			component.set({ foo: 3, bar: 4 });
+
+			assert.deepEqual(observed, [
+				[[1, 2], [3, 4], '1 2']
+			]);
+		});
+
+		it('respects defer: true', () => {
+			const { component, target } = setup(`{{foo}} {{bar}}`, { foo: 1, bar: 2 });
+
+			const observed = [];
+
+			component.observeMany(['foo', 'bar'], (n, o) => {
+				observed.push([o, n, target.innerHTML]);
+			}, {
+				defer: true
+			});
+
+			component.set({ foo: 3, bar: 4 });
+
+			assert.deepEqual(observed, [
+				[[undefined, undefined], [1, 2], '1 2'],
+				[[1, 2], [3, 4], '3 4']
+			]);
+		});
+	});
+};

--- a/test/setup.js
+++ b/test/setup.js
@@ -54,6 +54,7 @@ module.exports = function setup(
 					reverse,
 					tween,
 					observeDeep,
+					observeMany,
 					getDeep,
 					setDeep,
 					spring

--- a/test/tests.js
+++ b/test/tests.js
@@ -9,6 +9,7 @@ describe('svelte-extras', () => {
 	require('./array-methods/index.js')();
 	require('./tween/index.js')();
 	require('./observeDeep/index.js')();
+	require('./observeMany/index.js')();
 	require('./getDeep/index.js')();
 	require('./setDeep/index.js')();
 	require('./spring/index.js')();


### PR DESCRIPTION
This adds an `observeMany` method that allows you to observe multiple properties (say, in order to redraw a canvas) without the callback firing once for each changed property.

It does so by abusing the `defer` option — we attach a 'pre' observer which fires the user's callback immediately, then increments a counter for each property that changed, blocking any further calls. We also attach a 'post' observer which decrements the number, resetting it to zero once the change has taken effect. (Mutatis mutandis for deferred many-observers.)

The first argument is an array of keys, while the second is a callback that receives two arrays — the new values, and the old values:

```js
component.observeMany(['foo', 'bar'], ([newFoo, newBar], [oldFoo, oldBar]) => {
  // ...
});
```